### PR TITLE
Improve error code consistency, document error codes, improve task API

### DIFF
--- a/libraries/ah_base/include/ah/buf.h
+++ b/libraries/ah_base/include/ah/buf.h
@@ -7,6 +7,7 @@
 #ifndef AH_BUF_H_
 #define AH_BUF_H_
 
+#include "assert.h"
 #include "internal/buf.h"
 
 #include <stddef.h>
@@ -15,8 +16,8 @@
 struct ah_buf {
 
     // Will always have two fields: `_octets` and `_size`. Their order and types
-    // will vary, however. Use ah_buf_set() to update and ah_buf_get_octets()
-    // and ah_buf_get_size() to query.
+    // will vary, however, with the targeted platform. Use ah_buf_set() to
+    // update and ah_buf_get_octets() and ah_buf_get_size() to query.
 
     AH_I_BUF_FIELDS
 };
@@ -28,14 +29,21 @@ struct ah_bufvec {
 
 ah_extern_inline uint8_t* ah_buf_get_octets(const ah_buf_t* buf)
 {
+    ah_assert_if_debug(buf != NULL);
+
     return (uint8_t*) buf->_octets;
 }
 
 ah_extern_inline size_t ah_buf_get_size(const ah_buf_t* buf)
 {
+    ah_assert_if_debug(buf != NULL);
+
     return (size_t) buf->_size;
 }
 
+// Error codes:
+// * AH_EINVAL       - `buf` is NULL or `octets` is NULL and `size` is positive.
+// * AH_EDOM [Win32] - `size` is too large to be representable by `buf`.
 ah_extern ah_err_t ah_buf_set(ah_buf_t* buf, uint8_t* octets, size_t size);
 
 #endif

--- a/libraries/ah_base/include/ah/defs.h
+++ b/libraries/ah_base/include/ah/defs.h
@@ -116,7 +116,6 @@ typedef struct ah_sockaddr_ip ah_sockaddr_ip_t;
 typedef struct ah_sockaddr_ipv4 ah_sockaddr_ipv4_t;
 typedef struct ah_sockaddr_ipv6 ah_sockaddr_ipv6_t;
 typedef struct ah_task ah_task_t;
-typedef struct ah_task_opts ah_task_opts_t;
 typedef struct ah_tcp_listen_ctx ah_tcp_listen_ctx_t;
 typedef struct ah_tcp_read_ctx ah_tcp_read_ctx_t;
 typedef struct ah_tcp_sock ah_tcp_sock_t;

--- a/libraries/ah_base/include/ah/defs.h
+++ b/libraries/ah_base/include/ah/defs.h
@@ -36,7 +36,6 @@
 #endif
 
 #define AH_HAS_BSD_SOCKETS (AH_USE_IOCP || AH_USE_KQUEUE || AH_USE_URING)
-#define AH_HAS_TASK_QUEUE  (AH_USE_KQUEUE || AH_USE_URING)
 #define AH_HAS_POSIX       (AH_USE_KQUEUE || AH_USE_URING)
 
 #if defined(__clang__)

--- a/libraries/ah_base/include/ah/internal/kqueue/tcp.h
+++ b/libraries/ah_base/include/ah/internal/kqueue/tcp.h
@@ -10,7 +10,7 @@
 #define AH_I_TCP_LISTEN_CTX_PLATFORM_FIELDS
 #define AH_I_TCP_READ_CTX_PLATFORM_FIELDS
 
-#define AH_I_TCP_SOCK_PLATFORM_FIELDS                                                                                           \
+#define AH_I_TCP_SOCK_PLATFORM_FIELDS                                                                                  \
     struct ah_i_loop_evt* _read_or_listen_evt;                                                                         \
     ah_i_sockfd_t _fd;
 

--- a/libraries/ah_base/include/ah/loop.h
+++ b/libraries/ah_base/include/ah/loop.h
@@ -18,13 +18,47 @@ struct ah_loop_opts {
     size_t capacity;
 };
 
+// Error codes:
+// * AH_EINVAL       - `loop` or `opts` is NULL.
+// * AH_EMFILE       - [Darwin, Linux] Per-process file descriptor table is full.
+// * AH_ENFILE       - [Darwin, Linux] Platform file table is full.
+// * AH_ENOMEM       - [Darwin, Linux] Failed to allocate kernel memory for event queue.
+// * AH_ENOMEM       - `opts->alloc_cb` failed to allocate required memory.
+// * AH_EOVERFLOW    - [Linux] More than 32-bits of heap memory was requested on a 32-bit system.
+// * AH_EPERM        - [Linux] Permission denied to set up required kernel resource.
+// * AH_EPROCLIM     - [Win32] Windows task limit reached.
+// * AH_ESYSNOTREADY - [Win32] Network subsystem not ready.
 ah_extern ah_err_t ah_loop_init(ah_loop_t* loop, ah_loop_opts_t* opts);
+
 ah_extern bool ah_loop_is_running(const ah_loop_t* loop);
 ah_extern bool ah_loop_is_term(const ah_loop_t* loop);
 ah_extern ah_time_t ah_loop_now(const ah_loop_t* loop);
+
+// Error codes:
+// * AH_EINVAL - `loop` is NULL.
+// * AH_ESTATE - `loop` is already running or has been terminated.
+// * AH_EACCES - [Darwin] Process lacks permission to register KQueue filter.
+// * AH_EINTR  - [Darwin, Linux] The process was interrupted by a signal.
+// * AH_ENOMEM - [Darwin, Linux] Failed to submit pending events due to no memory being available to the kernel.
 ah_extern ah_err_t ah_loop_run(ah_loop_t* loop);
+
+// Error codes:
+// * AH_EDOM   - `time` is too far into the future for it to be representable by the kernel event queue system.
+// * AH_EINVAL - `loop` is NULL.
+// * AH_ESTATE - `loop` is already running or has been terminated.
+// * AH_EACCES - [Darwin] Process lacks permission to register KQueue filter.
+// * AH_EINTR  - [Darwin, Linux] The process was interrupted by a signal.
+// * AH_ENOMEM - [Darwin, Linux] Failed to submit pending events due to no memory being available to the kernel.
 ah_extern ah_err_t ah_loop_run_until(ah_loop_t* loop, ah_time_t* time);
+
+// Error codes:
+// * AH_EINVAL - `loop` is NULL.
+// * AH_ESTATE - `loop` is not running.
 ah_extern ah_err_t ah_loop_stop(ah_loop_t* loop);
+
+// Error codes:
+// * AH_EINVAL - `loop` is NULL.
+// * AH_ESTATE - `loop` is already terminated.
 ah_extern ah_err_t ah_loop_term(ah_loop_t* loop);
 
 #endif

--- a/libraries/ah_base/include/ah/math.h
+++ b/libraries/ah_base/include/ah/math.h
@@ -12,6 +12,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// All `add`, `div`, `mul` and `sub` functions return AH_ENONE if successful,
+// AH_EINVAL if the `result` argument is NULL or AH_ERANGE if the operation
+// overflowed. The `div` functions additionally return AH_EDOM of the `b`
+// argument is zero. Division overflows are only possible with signed integer
+// divisions.
+
 ah_extern ah_err_t ah_add_int64(int64_t a, int64_t b, int64_t* result);
 ah_extern ah_err_t ah_div_int64(int64_t a, int64_t b, int64_t* result);
 ah_extern ah_err_t ah_mul_int64(int64_t a, int64_t b, int64_t* result);

--- a/libraries/ah_base/include/ah/task.h
+++ b/libraries/ah_base/include/ah/task.h
@@ -12,10 +12,10 @@
 
 #include <stddef.h>
 
-#define AH_TASK_STATE_INITIAL   0x01
-#define AH_TASK_STATE_SCHEDULED 0x02
-#define AH_TASK_STATE_EXECUTED  0x04
-#define AH_TASK_STATE_CANCELED  0x08
+#define AH_TASK_STATE_INITIAL   0u
+#define AH_TASK_STATE_SCHEDULED 1u
+#define AH_TASK_STATE_EXECUTED  2u
+#define AH_TASK_STATE_CANCELED  3u
 
 typedef unsigned ah_task_state_t;
 
@@ -26,12 +26,12 @@ struct ah_task {
 };
 
 struct ah_task_opts {
-    ah_loop_t* loop;
-    ah_task_cb cb;
+    ah_loop_t* loop; // Required.
+    ah_task_cb cb; // Required.
     void* data;
 };
 
-ah_extern ah_err_t ah_task_init(ah_task_t* task, const ah_task_opts_t* opts);
+ah_extern void ah_task_init(ah_task_t* task, const ah_task_opts_t* opts);
 
 ah_extern_inline void* ah_task_get_user_data(const ah_task_t* task)
 {
@@ -57,9 +57,16 @@ ah_extern_inline void ah_task_set_user_data(ah_task_t* task, void* user_data)
     task->_user_data = user_data;
 }
 
-ah_extern ah_err_t ah_task_cancel(ah_task_t* task);
+ah_extern void ah_task_cancel(ah_task_t* task);
+
+// Error codes:
+// * AH_EDOM    - [Darwin] `baseline` is too for into the future to be representable by the underlying event queue.
+// * AH_EINVAL  - `task` is NULL.
+// * AH_ENOBUFS - [Darwin, Linux] `task` event loop has no more slots available in its event queue and could not flush it to make more slots available.
+// * AH_ENOMEM  - [Darwin, Linux, Win32] `task` event loop failed to allocate heap memory via its configured allocator callback.
+// * AH_ESTATE  - `task` is already scheduled and has not yet been cancelled or executed.
 ah_extern ah_err_t ah_task_schedule_at(ah_task_t* task, struct ah_time baseline);
 
-ah_extern ah_err_t ah_task_term(ah_task_t* task);
+ah_extern void ah_task_term(ah_task_t* task);
 
 #endif

--- a/libraries/ah_base/include/ah/task.h
+++ b/libraries/ah_base/include/ah/task.h
@@ -25,13 +25,8 @@ struct ah_task {
     AH_I_TASK_FIELDS
 };
 
-struct ah_task_opts {
-    ah_loop_t* loop; // Required.
-    ah_task_cb cb; // Required.
-    void* data;
-};
-
-ah_extern void ah_task_init(ah_task_t* task, const ah_task_opts_t* opts);
+// All arguments must be non-NULL.
+ah_extern void ah_task_init(ah_task_t* task, ah_loop_t* loop, ah_task_cb cb);
 
 ah_extern_inline void* ah_task_get_user_data(const ah_task_t* task)
 {

--- a/libraries/ah_base/include/ah/tcp.h
+++ b/libraries/ah_base/include/ah/tcp.h
@@ -83,7 +83,7 @@ ah_extern ah_err_t ah_tcp_listen(ah_tcp_sock_t* sock, unsigned backlog, ah_tcp_l
 
 ah_extern ah_err_t ah_tcp_read_start(ah_tcp_sock_t* sock, ah_tcp_read_ctx_t* ctx);
 ah_extern ah_err_t ah_tcp_read_stop(ah_tcp_sock_t* sock); // Caller is responsible for freeing any memory allocated by ah_tcp_read_start().
-ah_extern ah_err_t ah_tcp_write(ah_tcp_sock_t* sock, ah_tcp_write_ctx_t* ctx);
+ah_extern ah_err_t ah_tcp_write(ah_tcp_sock_t* sock, ah_tcp_write_ctx_t* ctx); // May modify ctx->bufvec and its items.
 ah_extern ah_err_t ah_tcp_shutdown(ah_tcp_sock_t* sock, ah_tcp_shutdown_t flags);
 
 ah_extern ah_err_t ah_tcp_close(ah_tcp_sock_t* sock, ah_tcp_close_cb cb);

--- a/libraries/ah_base/include/ah/time.h
+++ b/libraries/ah_base/include/ah/time.h
@@ -33,30 +33,57 @@ struct ah_time {
 typedef int64_t ah_timediff_t; // Nanoseconds.
 
 ah_extern ah_time_t ah_time_now(void);
+
+// Error codes:
+// * AH_EINVAL - `diff` is NULL.
+// * AH_ERANGE - Subtracting `b` from `a` produced an unrepresentable result.
 ah_extern ah_err_t ah_time_diff(ah_time_t a, ah_time_t b, ah_timediff_t* diff);
+
 ah_extern bool ah_time_eq(ah_time_t a, ah_time_t b);
 ah_extern int ah_time_cmp(ah_time_t a, ah_time_t b);
+
+// Error codes:
+// * AH_EINVAL - `result` is NULL.
+// * AH_ERANGE - Adding `diff` to `time` produced an unrepresentable result.
 ah_extern ah_err_t ah_time_add(ah_time_t time, ah_timediff_t diff, ah_time_t* result);
+
+// Error codes:
+// * AH_EINVAL - `result` is NULL.
+// * AH_ERANGE - Subtracting `diff` from `time` produced an unrepresentable result.
 ah_extern ah_err_t ah_time_sub(ah_time_t time, ah_timediff_t diff, ah_time_t* result);
+
 ah_extern bool ah_time_is_after(ah_time_t a, ah_time_t b);
 ah_extern bool ah_time_is_before(ah_time_t a, ah_time_t b);
 ah_extern bool ah_time_is_zero(ah_time_t time);
 
+// Error codes:
+// * AH_EINVAL - `result` is NULL.
+// * AH_ERANGE - Adding `a` and `b` produced an unrepresentable result.
 ah_extern_inline ah_err_t ah_timediff_add(ah_timediff_t a, ah_timediff_t b, ah_timediff_t* result)
 {
     return ah_add_int64(a, b, result);
 }
 
+// Error codes:
+// * AH_EDOM   - `b` is 0.
+// * AH_EINVAL - `result` is NULL.
+// * AH_ERANGE - Dividing `a` with `b` produced an unrepresentable result.
 ah_extern_inline ah_err_t ah_timediff_div(ah_timediff_t a, ah_timediff_t b, ah_timediff_t* result)
 {
     return ah_div_int64(a, b, result);
 }
 
+// Error codes:
+// * AH_EINVAL - `result` is NULL.
+// * AH_ERANGE - Multiplying `a` with `b` produced an unrepresentable result.
 ah_extern_inline ah_err_t ah_timediff_mul(ah_timediff_t a, ah_timediff_t b, ah_timediff_t* result)
 {
     return ah_mul_int64(a, b, result);
 }
 
+// Error codes:
+// * AH_EINVAL - `result` is NULL.
+// * AH_ERANGE - Subtracting `a` and `b` produced an unrepresentable result.
 ah_extern_inline ah_err_t ah_timediff_sub(ah_timediff_t a, ah_timediff_t b, ah_timediff_t* result)
 {
     return ah_sub_int64(a, b, result);

--- a/libraries/ah_base/src/iocp/loop.c
+++ b/libraries/ah_base/src/iocp/loop.c
@@ -79,7 +79,7 @@ ah_err_t ah_i_loop_poll_no_longer_than_until(ah_loop_t* loop, ah_time_t* time)
             if (poll_baseline != NULL) {
                 err = ah_time_diff(*poll_baseline, loop->_now, &poll_timeout);
                 if (err != AH_ENONE) {
-                    return err;
+                    return AH_EDOM;
                 }
             }
             else {

--- a/libraries/ah_base/src/iocp/tcp.c
+++ b/libraries/ah_base/src/iocp/tcp.c
@@ -218,7 +218,7 @@ static void s_on_accept(ah_i_loop_evt_t* evt)
     ah_tcp_sock_t* conn = NULL;
     ctx->alloc_cb(listener, &conn);
     if (conn == NULL) {
-        err = AH_ENOMEM;
+        err = AH_ENOBUFS;
         goto handle_err;
     }
     *conn = (ah_tcp_sock_t) {
@@ -300,7 +300,7 @@ static ah_err_t s_prep_read(ah_tcp_sock_t* sock, ah_tcp_read_ctx_t* ctx)
 
     ctx->alloc_cb(sock, &ctx->_bufvec, 0u);
     if (ctx->_bufvec.items == NULL) {
-        return AH_ENOMEM;
+        return AH_ENOBUFS;
     }
 
     WSABUF* buffers;

--- a/libraries/ah_base/src/iocp/udp.c
+++ b/libraries/ah_base/src/iocp/udp.c
@@ -66,7 +66,7 @@ static ah_err_t s_prep_recv(ah_udp_sock_t* sock, ah_udp_recv_ctx_t* ctx)
     struct ah_bufvec bufvec = { .items = NULL, .length = 0u };
     ctx->alloc_cb(sock, &bufvec, 0u);
     if (bufvec.items == NULL) {
-        return AH_ENOMEM;
+        return AH_ENOBUFS;
     }
 
     WSABUF* buffers;

--- a/libraries/ah_base/src/kqueue/task.c
+++ b/libraries/ah_base/src/kqueue/task.c
@@ -66,7 +66,7 @@ ah_extern ah_err_t ah_i_task_schedule_at(ah_task_t* task, struct ah_time baselin
         data = 0;
     }
     else if (ah_p_sub_overflow(a, b, &data)) {
-        return AH_ERANGE;
+        return AH_DOM;
     }
 
 #endif

--- a/libraries/ah_base/src/kqueue/tcp.c
+++ b/libraries/ah_base/src/kqueue/tcp.c
@@ -259,7 +259,7 @@ static void s_on_read(ah_i_loop_evt_t* evt, struct kevent* kev)
         bufvec = (ah_bufvec_t) { .items = NULL, .length = 0u };
         ctx->alloc_cb(sock, &bufvec, n_bytes_left);
         if (bufvec.items == NULL) {
-            err = AH_ENOMEM;
+            err = AH_ENOBUFS;
             goto call_read_cb_with_err_and_return;
         }
 
@@ -312,12 +312,11 @@ ah_extern ah_err_t ah_tcp_read_stop(ah_tcp_sock_t* sock)
 
     struct kevent* kev;
     ah_err_t err = ah_i_loop_alloc_kev(sock->_loop, &kev);
-    if (err == AH_ENONE) {
-        EV_SET(kev, sock->_fd, EVFILT_READ, EV_DELETE, 0, 0u, NULL);
+    if (err != AH_ENONE) {
+        return err == AH_ENOBUFS ? AH_ENONE : err;
     }
-    else if (err == AH_ENOMEM) {
-        return err;
-    }
+
+    EV_SET(kev, sock->_fd, EVFILT_READ, EV_DELETE, 0, 0u, NULL);
 
     return AH_ENONE;
 }

--- a/libraries/ah_base/src/kqueue/tcp.c
+++ b/libraries/ah_base/src/kqueue/tcp.c
@@ -10,7 +10,6 @@
 #include "ah/err.h"
 #include "ah/loop.h"
 
-#include <netinet/tcp.h>
 #include <stddef.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
@@ -19,6 +18,8 @@ static void s_on_accept(ah_i_loop_evt_t* evt, struct kevent* kev);
 static void s_on_connect(ah_i_loop_evt_t* evt, struct kevent* kev);
 static void s_on_read(ah_i_loop_evt_t* evt, struct kevent* kev);
 static void s_on_write(ah_i_loop_evt_t* evt, struct kevent* kev);
+
+static ah_err_t s_prep_write(ah_tcp_sock_t* sock, ah_tcp_write_ctx_t* ctx);
 
 ah_extern ah_err_t ah_tcp_connect(ah_tcp_sock_t* sock, const ah_sockaddr_t* remote_addr, ah_tcp_connect_cb cb)
 {
@@ -87,7 +88,7 @@ static void s_on_connect(ah_i_loop_evt_t* evt, struct kevent* kev)
         err = (ah_err_t) kev->data;
     }
     else if (ah_unlikely((kev->flags & EV_EOF) != 0)) {
-        err = AH_EEOF;
+        err = kev->fflags != 0 ? (ah_err_t) kev->fflags : AH_EEOF;
     }
     else {
         err = AH_ENONE;
@@ -193,7 +194,7 @@ static void s_on_accept(ah_i_loop_evt_t* evt, struct kevent* kev)
     }
 
     if (ah_unlikely((kev->flags & EV_EOF) != 0)) {
-        ctx->listen_cb(listener, AH_EEOF);
+        ctx->listen_cb(listener, kev->fflags != 0 ? (ah_err_t) kev->fflags : AH_EEOF);
     }
 }
 
@@ -288,7 +289,7 @@ static void s_on_read(ah_i_loop_evt_t* evt, struct kevent* kev)
     }
 
     if (ah_unlikely((kev->flags & EV_EOF) != 0)) {
-        err = AH_EEOF;
+        err = kev->fflags != 0 ? (ah_err_t) kev->fflags : AH_EEOF;
         sock->_state_read = AH_I_TCP_STATE_READ_OFF;
         goto call_read_cb_with_err_and_return;
     }
@@ -333,6 +334,26 @@ ah_extern ah_err_t ah_tcp_write(ah_tcp_sock_t* sock, ah_tcp_write_ctx_t* ctx)
         return AH_ESTATE;
     }
 
+    if (ctx->bufvec.length == 0u) {
+        ctx->write_cb(sock, AH_ENONE);
+        return AH_ENONE;
+    }
+
+    ah_err_t err = s_prep_write(sock, ctx);
+    if (err != AH_ENONE) {
+        return err;
+    }
+
+    sock->_state_write = AH_I_TCP_STATE_WRITE_STARTED;
+
+    return AH_ENONE;
+}
+
+static ah_err_t s_prep_write(ah_tcp_sock_t* sock, ah_tcp_write_ctx_t* ctx)
+{
+    ah_assert_if_debug(sock != NULL);
+    ah_assert_if_debug(ctx != NULL);
+
     ah_i_loop_evt_t* evt;
     struct kevent* kev;
 
@@ -346,8 +367,6 @@ ah_extern ah_err_t ah_tcp_write(ah_tcp_sock_t* sock, ah_tcp_write_ctx_t* ctx)
     evt->_body._tcp_write._ctx = ctx;
 
     EV_SET(kev, sock->_fd, EVFILT_WRITE, EV_ADD | EV_ONESHOT, 0u, 0, evt);
-
-    sock->_state_write = AH_I_TCP_STATE_WRITE_STARTED;
 
     return AH_ENONE;
 }
@@ -373,33 +392,57 @@ static void s_on_write(ah_i_loop_evt_t* evt, struct kevent* kev)
 
     if (ah_unlikely((kev->flags & EV_ERROR) != 0)) {
         err = (ah_err_t) kev->data;
-        goto set_is_writing_to_false_and_call_write_cb_with_conn_err;
+        goto stop_writing_and_report_err;
     }
 
     if (ah_unlikely((kev->flags & EV_EOF) != 0)) {
-        err = AH_EEOF;
+        err = kev->fflags != 0 ? (ah_err_t) kev->fflags : AH_EEOF;
         sock->_state_write = AH_I_TCP_STATE_WRITE_OFF;
-        goto set_is_writing_to_false_and_call_write_cb_with_conn_err;
+        goto report_err;
     }
 
-    struct iovec* iov;
-    int iovcnt;
-    err = ah_i_bufvec_into_iovec(&ctx->bufvec, &iov, &iovcnt);
+    struct iovec* iovecs;
+    int iovecs_length;
+    err = ah_i_bufvec_into_iovec(&ctx->bufvec, &iovecs, &iovecs_length);
     if (ah_unlikely(err != AH_ENONE)) {
         err = AH_EDOM;
-        goto set_is_writing_to_false_and_call_write_cb_with_conn_err;
+        goto stop_writing_and_report_err;
     }
 
-    ssize_t res = writev(sock->_fd, iov, iovcnt);
+    ssize_t res = writev(sock->_fd, iovecs, iovecs_length);
     if (ah_unlikely(res < 0)) {
         err = errno;
-        goto set_is_writing_to_false_and_call_write_cb_with_conn_err;
+        goto stop_writing_and_report_err;
+    }
+
+    // If there is more to write, adjust bufvec and schedule another writing.
+    for (size_t i = 0u; i < ctx->bufvec.length; i += 1u) {
+        ah_buf_t* buf = &ctx->bufvec.items[0u];
+
+        if (((size_t) res) >= buf->_size) {
+            res -= (ssize_t) buf->_size;
+            continue;
+        }
+
+        ctx->bufvec.items = &ctx->bufvec.items[i];
+        ctx->bufvec.length -= i;
+
+        buf->_octets = &buf->_octets[(size_t) res];
+        buf->_size -= (size_t) res;
+
+        err = s_prep_write(sock, ctx);
+        if (err != AH_ENONE) {
+            goto stop_writing_and_report_err;
+        }
+        return;
     }
 
     err = AH_ENONE;
 
-set_is_writing_to_false_and_call_write_cb_with_conn_err:
+stop_writing_and_report_err:
     sock->_state_write = AH_I_TCP_STATE_WRITE_STOPPED;
+
+report_err:
     ctx->write_cb(sock, err);
 }
 

--- a/libraries/ah_base/src/kqueue/udp.c
+++ b/libraries/ah_base/src/kqueue/udp.c
@@ -75,7 +75,7 @@ static void s_on_recv(ah_i_loop_evt_t* evt, struct kevent* kev)
     struct ah_bufvec bufvec = { .items = NULL, .length = 0u };
     ctx->alloc_cb(sock, &bufvec, dgram_size);
     if (bufvec.items == NULL) {
-        err = AH_ENOMEM;
+        err = AH_ENOBUFS;
         goto call_recv_cb_with_err_and_return;
     }
 
@@ -132,7 +132,7 @@ ah_extern ah_err_t ah_udp_recv_stop(ah_udp_sock_t* sock)
     struct kevent* kev;
     ah_err_t err = ah_i_loop_alloc_kev(sock->_loop, &kev);
     if (err != AH_ENONE) {
-        return err == AH_ENOMEM ? AH_ENONE : err;
+        return err == AH_ENOBUFS ? AH_ENONE : err;
     }
 
     EV_SET(kev, sock->_fd, EVFILT_READ, EV_DELETE, 0, 0u, NULL);

--- a/libraries/ah_base/src/kqueue/udp.c
+++ b/libraries/ah_base/src/kqueue/udp.c
@@ -34,7 +34,7 @@ ah_extern ah_err_t ah_udp_recv_start(ah_udp_sock_t* sock, ah_udp_recv_ctx_t* ctx
     evt->_body._udp_recv._sock = sock;
     evt->_body._udp_recv._ctx = ctx;
 
-    EV_SET(kev, sock->_fd, EVFILT_READ, EV_ADD, 0u, 0, evt);
+    EV_SET(kev, sock->_fd, EVFILT_READ, EV_ADD | EV_CLEAR, 0u, 0, evt);
 
     sock->_is_receiving = true;
 
@@ -109,7 +109,7 @@ static void s_on_recv(ah_i_loop_evt_t* evt, struct kevent* kev)
     }
 
     if (ah_unlikely((kev->flags & EV_EOF) != 0)) {
-        err = AH_EEOF;
+        err = kev->fflags != 0 ? (ah_err_t) kev->fflags : AH_EEOF;
         goto call_recv_cb_with_err_and_return;
     }
 
@@ -131,12 +131,11 @@ ah_extern ah_err_t ah_udp_recv_stop(ah_udp_sock_t* sock)
 
     struct kevent* kev;
     ah_err_t err = ah_i_loop_alloc_kev(sock->_loop, &kev);
-    if (err == AH_ENONE) {
-        EV_SET(kev, sock->_fd, EVFILT_READ, EV_DELETE, 0, 0u, NULL);
+    if (err != AH_ENONE) {
+        return err == AH_ENOMEM ? AH_ENONE : err;
     }
-    else if (err == AH_ENOMEM) {
-        return err;
-    }
+
+    EV_SET(kev, sock->_fd, EVFILT_READ, EV_DELETE, 0, 0u, NULL);
 
     return AH_ENONE;
 }
@@ -191,7 +190,7 @@ static void s_on_send(ah_i_loop_evt_t* evt, struct kevent* kev)
     }
 
     if (ah_unlikely((kev->flags & EV_EOF) != 0)) {
-        err = AH_EEOF;
+        err = kev->fflags != 0 ? (ah_err_t) kev->fflags : AH_EEOF;
         goto call_send_cb_with_sock_and_err;
     }
 

--- a/libraries/ah_base/src/task.c
+++ b/libraries/ah_base/src/task.c
@@ -9,17 +9,15 @@
 #include "ah/err.h"
 #include "ah/loop.h"
 
-ah_extern void ah_task_init(ah_task_t* task, const ah_task_opts_t* opts)
+ah_extern void ah_task_init(ah_task_t* task, ah_loop_t* loop, ah_task_cb cb)
 {
     ah_assert_if_debug(task != NULL);
-    ah_assert_if_debug(opts != NULL);
-    ah_assert_if_debug(opts->loop != NULL);
-    ah_assert_if_debug(opts->cb != NULL);
+    ah_assert_if_debug(loop != NULL);
+    ah_assert_if_debug(cb != NULL);
 
     *task = (ah_task_t) {
-        ._loop = opts->loop,
-        ._cb = opts->cb,
-        ._user_data = opts->data,
+        ._loop = loop,
+        ._cb = cb,
         ._state = AH_TASK_STATE_INITIAL,
     };
 }

--- a/libraries/ah_base/src/task.c
+++ b/libraries/ah_base/src/task.c
@@ -9,15 +9,12 @@
 #include "ah/err.h"
 #include "ah/loop.h"
 
-#define S_STATE_MASK (AH_TASK_STATE_INITIAL | AH_TASK_STATE_SCHEDULED | AH_TASK_STATE_EXECUTED | AH_TASK_STATE_CANCELED)
-
-static void s_cancel(ah_task_t* task);
-
-ah_extern ah_err_t ah_task_init(ah_task_t* task, const ah_task_opts_t* opts)
+ah_extern void ah_task_init(ah_task_t* task, const ah_task_opts_t* opts)
 {
-    if (task == NULL || opts == NULL || opts->loop == NULL || opts->cb == NULL) {
-        return AH_EINVAL;
-    }
+    ah_assert_if_debug(task != NULL);
+    ah_assert_if_debug(opts != NULL);
+    ah_assert_if_debug(opts->loop != NULL);
+    ah_assert_if_debug(opts->cb != NULL);
 
     *task = (ah_task_t) {
         ._loop = opts->loop,
@@ -25,47 +22,17 @@ ah_extern ah_err_t ah_task_init(ah_task_t* task, const ah_task_opts_t* opts)
         ._user_data = opts->data,
         ._state = AH_TASK_STATE_INITIAL,
     };
-
-    return AH_ENONE;
 }
 
-ah_extern ah_err_t ah_task_cancel(ah_task_t* task)
-{
-    if (task == NULL) {
-        return AH_EINVAL;
-    }
-    if ((task->_state & S_STATE_MASK) == 0) {
-        return AH_ESTATE;
-    }
-
-    s_cancel(task);
-
-    task->_cb(task, AH_ECANCELED);
-
-    return AH_ENONE;
-}
-
-static void s_cancel(ah_task_t* task)
+ah_extern void ah_task_cancel(ah_task_t* task)
 {
     ah_assert_if_debug(task != NULL);
 
-    switch (task->_state) {
-    case AH_TASK_STATE_INITIAL:
-        break;
-
-    case AH_TASK_STATE_SCHEDULED:
+    if (task->_state == AH_TASK_STATE_SCHEDULED) {
         ah_i_task_cancel_scheduled(task);
-        break;
-
-    case AH_TASK_STATE_EXECUTED:
-    case AH_TASK_STATE_CANCELED:
-        break;
-
-    default:
-        ah_unreachable();
+        task->_state = AH_TASK_STATE_CANCELED;
+        task->_cb(task, AH_ECANCELED);
     }
-
-    task->_state = AH_TASK_STATE_CANCELED;
 }
 
 ah_extern ah_err_t ah_task_schedule_at(ah_task_t* task, struct ah_time baseline)
@@ -73,8 +40,17 @@ ah_extern ah_err_t ah_task_schedule_at(ah_task_t* task, struct ah_time baseline)
     if (task == NULL) {
         return AH_EINVAL;
     }
-    if (task->_state != AH_TASK_STATE_INITIAL) {
+    switch (task->_state) {
+    case AH_TASK_STATE_INITIAL:
+    case AH_TASK_STATE_EXECUTED:
+    case AH_TASK_STATE_CANCELED:
+        break;
+
+    case AH_TASK_STATE_SCHEDULED:
         return AH_ESTATE;
+
+    default:
+        ah_unreachable();
     }
 
     ah_err_t err = ah_i_task_schedule_at(task, baseline);
@@ -87,16 +63,15 @@ ah_extern ah_err_t ah_task_schedule_at(ah_task_t* task, struct ah_time baseline)
     return AH_ENONE;
 }
 
-ah_extern ah_err_t ah_task_term(ah_task_t* task)
+ah_extern void ah_task_term(ah_task_t* task)
 {
-    if (task == NULL) {
-        return AH_EINVAL;
-    }
+    ah_assert_if_debug(task != NULL);
+
     if (task->_state == AH_TASK_STATE_SCHEDULED) {
-        s_cancel(task);
+        ah_i_task_cancel_scheduled(task);
+        task->_state = AH_TASK_STATE_CANCELED;
     }
 #ifndef NDEBUG
     *task = (ah_task_t) { 0 };
 #endif
-    return AH_ENONE;
 }

--- a/libraries/ah_base/src/uring/loop.c
+++ b/libraries/ah_base/src/uring/loop.c
@@ -76,7 +76,7 @@ ah_err_t ah_i_loop_poll_no_longer_than_until(ah_loop_t* loop, struct ah_time* ti
         ah_timediff_t diff;
         err = ah_time_diff(*time, loop->_now, &diff);
         if (err != AH_ENONE) {
-            return err;
+            return AH_EDOM;
         }
         if (diff < 0) {
             diff = 0;
@@ -181,17 +181,17 @@ ah_err_t ah_i_loop_alloc_sqe(ah_loop_t* loop, struct io_uring_sqe** sqe)
         if (ah_unlikely(res < 0)) {
             if (res != -EAGAIN && res != -EBUSY) {
                 loop->_pending_err = -res;
-                return AH_ENOMEM;
+                return AH_ENOBUFS;
             }
             ah_err_t err = ah_i_loop_poll_no_longer_than_until(loop, NULL);
             if (err != AH_ENONE) {
                 loop->_pending_err = err;
-                return AH_ENOMEM;
+                return AH_ENOBUFS;
             }
         }
         sqe0 = io_uring_get_sqe(&loop->_uring);
         if (ah_unlikely(sqe0 == NULL)) {
-            return AH_ENOMEM;
+            return AH_ENOBUFS;
         }
     }
 

--- a/libraries/ah_base/src/uring/tcp.c
+++ b/libraries/ah_base/src/uring/tcp.c
@@ -214,7 +214,7 @@ static ah_err_t s_prep_read(ah_tcp_sock_t* sock, ah_tcp_read_ctx_t* ctx)
     ctx->_bufvec.length = 0u;
     ctx->alloc_cb(sock, &ctx->_bufvec, 0u);
     if (ctx->_bufvec.items == NULL) {
-        return AH_ENOMEM;
+        return AH_ENOBUFS;
     }
 
     struct iovec* iov;

--- a/libraries/ah_base/src/uring/udp.c
+++ b/libraries/ah_base/src/uring/udp.c
@@ -55,7 +55,7 @@ static ah_err_t s_prep_recv(ah_udp_sock_t* sock, ah_udp_recv_ctx_t* ctx)
     struct ah_bufvec bufvec = { .items = NULL, .length = 0u };
     ctx->alloc_cb(sock, &bufvec, 0u);
     if (bufvec.items == NULL) {
-        return AH_ENOMEM;
+        return AH_ENOBUFS;
     }
 
     struct iovec* iov;

--- a/libraries/ah_base/test/task.c
+++ b/libraries/ah_base/test/task.c
@@ -59,10 +59,7 @@ static void s_should_execute_task_with_no_err(ah_unit_t* unit)
         .unit = unit,
     };
     struct ah_task_opts task_options = { .loop = &loop, .cb = s_on_execution, .data = &task_data };
-    err = ah_task_init(&task, &task_options);
-    if (!ah_unit_assert_enum_eq(unit, AH_ENONE, err, ah_strerror)) {
-        return;
-    }
+    ah_task_init(&task, &task_options);
 
     err = ah_task_schedule_at(&task, (struct ah_time) { 0u });
     if (!ah_unit_assert_enum_eq(unit, AH_ENONE, err, ah_strerror)) {
@@ -99,20 +96,14 @@ static void s_should_execute_cancelled_task_with_correct_err(ah_unit_t* unit)
         .unit = unit,
     };
     struct ah_task_opts task_options = { .loop = &loop, .cb = s_on_execution, .data = &task_data };
-    err = ah_task_init(&task, &task_options);
-    if (!ah_unit_assert_enum_eq(unit, AH_ENONE, err, ah_strerror)) {
-        return;
-    }
+    ah_task_init(&task, &task_options);
 
     err = ah_task_schedule_at(&task, (struct ah_time) { 0u });
     if (!ah_unit_assert_enum_eq(unit, AH_ENONE, err, ah_strerror)) {
         return;
     }
 
-    err = ah_task_cancel(&task);
-    if (!ah_unit_assert_enum_eq(unit, AH_ENONE, err, ah_strerror)) {
-        return;
-    }
+    ah_task_cancel(&task);
 
     err = ah_loop_run_until(&loop, &(struct ah_time) { 0u });
     if (!ah_unit_assert_enum_eq(unit, AH_ENONE, err, ah_strerror)) {

--- a/libraries/ah_base/test/task.c
+++ b/libraries/ah_base/test/task.c
@@ -58,8 +58,8 @@ static void s_should_execute_task_with_no_err(ah_unit_t* unit)
         .call_counter = &call_counter,
         .unit = unit,
     };
-    struct ah_task_opts task_options = { .loop = &loop, .cb = s_on_execution, .data = &task_data };
-    ah_task_init(&task, &task_options);
+    ah_task_init(&task, &loop, s_on_execution);
+    ah_task_set_user_data(&task, &task_data);
 
     err = ah_task_schedule_at(&task, (struct ah_time) { 0u });
     if (!ah_unit_assert_enum_eq(unit, AH_ENONE, err, ah_strerror)) {
@@ -95,8 +95,8 @@ static void s_should_execute_cancelled_task_with_correct_err(ah_unit_t* unit)
         .call_counter = &call_counter,
         .unit = unit,
     };
-    struct ah_task_opts task_options = { .loop = &loop, .cb = s_on_execution, .data = &task_data };
-    ah_task_init(&task, &task_options);
+    ah_task_init(&task, &loop, s_on_execution);
+    ah_task_set_user_data(&task, &task_data);
 
     err = ah_task_schedule_at(&task, (struct ah_time) { 0u });
     if (!ah_unit_assert_enum_eq(unit, AH_ENONE, err, ah_strerror)) {


### PR DESCRIPTION
Fixes various things I found that needed to be done around the ah_base library. I skipped giving the udp and tcp modules the treatment I gave to the rest of the library, as I suspect these APIs may have to change as I write the HTTP and TLS modules.